### PR TITLE
Add AUTLocalizationNotNeeded()

### DIFF
--- a/AUTExtObjC/AUTExtObjC.h
+++ b/AUTExtObjC/AUTExtObjC.h
@@ -11,3 +11,4 @@
 #import "AUTStrongifyOr.h"
 #import "AUTUnavailableDesignatedInitializer.h"
 #import "AUTAutoType.h"
+#import "AUTLocalizationNotNeeded.h"

--- a/AUTExtObjC/AUTLocalizationNotNeeded.h
+++ b/AUTExtObjC/AUTLocalizationNotNeeded.h
@@ -1,0 +1,19 @@
+//
+//  AUTLocalizationNotNeeded.h
+//  Automatic
+//
+//  Created by Eric Horacek on 1/19/17.
+//  Copyright © 2017 Automatic Labs. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Tells the clang analyzer that this string does not need to be localized (by
+/// marking it as localized).
+///
+/// See http://clang-analyzer.llvm.org/faq.html#unlocalized_string
+__attribute__((annotate("returns_localized_nsstring"))) static inline NSString * _Nullable AUTLocalizationNotNeeded(NSString * _Nullable string) {
+    return string;
+}
+
+NS_ASSUME_NONNULL_END

--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ Reduces boilerplate when opting out of designated initializers.
 ```objc
 - (instancetype)initWithCoder:(NSCoder *)aDecoder AUT_UNAVAILABLE_DESIGNATED_INITIALIZER;
 ```
+
+## `AUTLocalizationNotNeeded()`
+
+Tells the clang analyzer that a string does not need localization if the
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED build setting is on.
+
+```objc
+label.text = AUTLocalizationNotNeeded(@"Secret Developer Menu");
+```


### PR DESCRIPTION
Tells the clang analyzer that this string does not need to be localized (by marking it as localized).

See http://clang-analyzer.llvm.org/faq.html#unlocalized_string